### PR TITLE
Fix CBA settings "isGlobal" var

### DIFF
--- a/addons/functions/XEH_preInit.sqf
+++ b/addons/functions/XEH_preInit.sqf
@@ -11,7 +11,7 @@ PREP_RECOMPILE_END;
     ["Rank size", "Additional rank size slider."],
     ["ETR Enhanced Ranks", "General"],
     [0.75, 3, 1, 0, true],
-    2
+    false
 ] call CBA_fnc_addSetting;
 
 [
@@ -19,7 +19,7 @@ PREP_RECOMPILE_END;
     ["Default rank info", "Default values used for rank info, only for players."],
     ["ETR Enhanced Ranks", "General"],
     '["default_faction","default_rank"]',
-    0,
+    true,
     {},
     true
 ] call CBA_fnc_addSetting;
@@ -29,7 +29,7 @@ PREP_RECOMPILE_END;
     ["UID system", "UID system selection."],
     ["ETR Enhanced Ranks", "General"],
     [[0, 1, 2], ["Disabled", "Config", "CBA Settings"], 0],
-    0,
+    true,
     {},
     true
 ] call CBA_fnc_addSetting;
@@ -39,7 +39,7 @@ PREP_RECOMPILE_END;
     ["UID settings amount", "How many different ranks should be editable via CBA settings? Requires a reopen of the mission to take effect."],
     ["ETR Enhanced Ranks", "UID Settings"],
     "10",
-    0,
+    true,
     {},
     true
 ] call CBA_fnc_addSetting;
@@ -50,7 +50,7 @@ for "_i" from 1 to (parseNumber GVARMAIN(uidSystem_amount)) do {
         [format["%1 - Rank",_i], ""],
         ["ETR Enhanced Ranks", "UID Settings"],
         '["default_faction","default_rank"]',
-        0,
+        true,
         {},
         false
     ] call CBA_fnc_addSetting;
@@ -60,12 +60,11 @@ for "_i" from 1 to (parseNumber GVARMAIN(uidSystem_amount)) do {
         [format["%1 - UIDs",_i], ""],
         ["ETR Enhanced Ranks", "UID Settings"],
         '["uid1","uid2"]',
-        0,
+        true,
         {},
         false
     ] call CBA_fnc_addSetting;
 };
-
 
 // Run init function to handle icon/faction stuff.
 ["CAManBase", "initPost", LINKFUNC(init), true, [], true] call CBA_fnc_addClassEventHandler;


### PR DESCRIPTION
Currently the variables don't get set correctly due to using the default, this fixes this.
Also made the rank size client side by default but overridable by mission or server.