### PR TITLE
Fix ranks not being initialized for JIP players 

### DIFF
--- a/addons/functions/functions/fnc_init.sqf
+++ b/addons/functions/functions/fnc_init.sqf
@@ -18,30 +18,32 @@
 
 params [["_unit", objNull]];
 
-// Only run for local units.
-if (!local _unit) exitWith {};
+private _handle = [{
+    params ["_unit"];
 
-(_unit getVariable ["etr_ranks_insigniaIcon", ["default_faction","default_rank"]]) params ["_faction", "_rank"];
+    // Only run for local units.
+    if (!local _unit) exitWith {};
 
-// Set rank icon.
-if ((GVAR(uidSystem) > 0) && {(isPlayer _unit)}) then {
-    // Get rank info from uid.
-    private _rankInfo = [getPlayerUID _unit] call FUNC(checkUID);
-    // Set rank info.
-    _unit setVariable ["etr_ranks_insigniaIcon", _rankInfo, true];
-    // Set icon.
-    [_unit, _rankInfo] call FUNC(setIcon);
-} else {
-    /*if (!isPlayer _unit) then {
-        // If AI check if units faction is not set, if this is true use the groupsleaders faction.
-        if (_rank isEqualTo "default_rank") then {
-            if ((_faction isEqualTo "default_faction") && {_unit isNotEqualTo (leader _unit)}) then {
-                _unit setVariable ["etr_ranks_insigniaIcon", [((leader _unit) getVariable ["etr_ranks_insigniaIcon", ["default_faction","default_rank"]])#0, "default_rank"], true];
-            };
+    (_unit getVariable ["etr_ranks_insigniaIcon", ["default_faction","default_rank"]]) params ["_faction", "_rank"];
+
+    // Set rank icon.
+    if ((GVAR(uidSystem) > 0) && {(isPlayer _unit)}) then {
+        // Get rank info from uid.
+        private _rankInfo = [getPlayerUID _unit] call FUNC(checkUID);
+        // Set rank info.
+        _unit setVariable ["etr_ranks_insigniaIcon", _rankInfo, true];
+        // Set icon.
+        [_unit, _rankInfo] call FUNC(setIcon);
+        // If unit is now player set higher pfh time to save resources
+        if !((_unit getVariable ["etr_ranks_unit_pfh_time", 30]) == 300) then {
+            _unit setVariable ["etr_ranks_unit_pfh_time", 300, true];
         };
-    };*/
-    [_unit] call FUNC(setIcon);
-};
+    } else {
+        [_unit] call FUNC(setIcon);
+    };
 
-// Add faction data, run on server.
-[getText ((configOf _unit) >> 'faction'), _faction] remoteExec [QFUNC(setFaction), 2];
+    // Add faction data, run on server.
+    [getText ((configOf _unit) >> 'faction'), _faction] remoteExec [QFUNC(setFaction), 2];
+},(_unit getVariable ["etr_ranks_unit_pfh_time", 30]),_unit] call CBA_fnc_addPerFrameHandler;
+
+_unit setVariable ["etr_ranks_unit_pfh", _handle, true];


### PR DESCRIPTION
The core problem is/was that the init fnc was only called once at mission start. If no player was slotted at a spot at this time the fnc would use the fallback and assign a default rank. Due to this file only being called ONCE join in progress players did not get their ranks updated. This change adds a PHF that checks every 30s if a unit is controlled by a player, if yes it applies the correct rank and sets to recheck time to 300s (5m) to save performance. The handle is saved in the "etr_ranks_unit_pfh" var if anyone wants to remove the PHF completely. 