### PR TITLE
Adjust default settings amount

### DIFF
--- a/addons/functions/XEH_preInit.sqf
+++ b/addons/functions/XEH_preInit.sqf
@@ -38,7 +38,7 @@ PREP_RECOMPILE_END;
     QGVARMAIN(uidSystem_amount), "EDITBOX",
     ["UID settings amount", "How many different ranks should be editable via CBA settings? Requires a reopen of the mission to take effect."],
     ["ETR Enhanced Ranks", "UID Settings"],
-    "10",
+    "25",
     0,
     {},
     true
@@ -48,7 +48,7 @@ PREP_RECOMPILE_END;
     QGVARMAIN(regexSystem_amount), "EDITBOX",
     ["Regex settings amount", "How many different ranks should be editable via CBA settings? Requires a reopen of the mission to take effect."],
     ["ETR Enhanced Ranks", "Regex Settings"],
-    "10",
+    "25",
     0,
     {},
     true


### PR DESCRIPTION
Basically the core problem is that "GVARMAIN(uidSystem_amount)" always uses the default value regardless if the server has a other value forced. This leads to ranks not being whitelisted cause they can not initialize over the default number this can partially be fixed by users setting the same number as the server in their CBA client settings. BUT the server force still does not work. So quick fix set the default to 25 so there are 25 options for ranks at default. I think no current ranks go above 25. This does not nix the core problem but prevents it from being "discovered" by units using it. (Maybe remove the whole add settings with number thing, It can work but is a lot of work to fix)